### PR TITLE
chore: rename google auth route

### DIFF
--- a/src/config/swagger.yaml
+++ b/src/config/swagger.yaml
@@ -167,11 +167,11 @@ paths:
         '500':
           description: Internal Server Error.
 
-  /register-google-user:
+  /google-auth:
     post:
       tags:
         - User
-      description: Register new user after google authentication and get JWT token
+      description: Authenticate with google account and get JWT token
       requestBody:
         required: true
         content:

--- a/src/controllers/user-controller.ts
+++ b/src/controllers/user-controller.ts
@@ -64,7 +64,7 @@ export const registerUser = async (
   }
 }
 
-export const registerUserWithGoogle = async (
+export const googleAuth = async (
   req: RequestBody<RegisterGoogleMemberReq>,
   res: Response
 ) => {

--- a/src/middlewares/auth-middleware.ts
+++ b/src/middlewares/auth-middleware.ts
@@ -8,7 +8,7 @@ const authMiddleware = (req: AuthBody, res: Response, next: Next) => {
 
     if (
       url.includes('/register-user') ||
-      url.includes('/register-google-user') ||
+      url.includes('/google-auth') ||
       url.includes('/verify-email') ||
       url.includes('/activate-account')
     ) {

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -2,7 +2,7 @@ import { googleUserSchema, passwordSchema, userSchema } from 'schemas'
 import { validateRequestSchema } from 'middlewares'
 import express, { RequestHandler } from 'express'
 import {
-  registerUserWithGoogle,
+  googleAuth,
   userAccountActivation,
   verifyUserEmail,
   changePassword,
@@ -26,12 +26,7 @@ router.post(
   changePassword as RequestHandler
 )
 
-router.post(
-  '/register-google-user',
-  googleUserSchema,
-  validateRequestSchema,
-  registerUserWithGoogle
-)
+router.post('/google-auth', googleUserSchema, validateRequestSchema, googleAuth)
 
 router.get('/verify-email', verifyUserEmail)
 


### PR DESCRIPTION
Change route and controller name, because those ones should be used for also google sign-in and not only for registration.